### PR TITLE
Fixed Lag with Arrows

### DIFF
--- a/Scenes/States/PlayState.gd
+++ b/Scenes/States/PlayState.gd
@@ -133,9 +133,15 @@ func button_logic(line, note):
 	var animation = button.get_node("AnimationPlayer")
 	
 	if (Input.is_action_pressed(action)):
-		if (PlayerCharacter != null && PlayerCharacter.get_node("AnimationPlayer").assigned_animation != PlayerCharacter.get_idle_anim()):
-			if (PlayerCharacter.idleTimer <= 0.05):
-				PlayerCharacter.idleTimer = 0.05
+		if PlayerCharacter != null:
+			if PlayerCharacter.has_node("AnimationPlayer"):
+				if PlayerCharacter.get_node("AnimationPlayer").assigned_animation != PlayerCharacter.get_idle_anim():
+					if (PlayerCharacter.idleTimer <= 0.05):
+						PlayerCharacter.idleTimer = 0.05
+			else:
+				if PlayerCharacter.get_node("AnimatedSprite").animation != PlayerCharacter.get_idle_anim():
+					if (PlayerCharacter.idleTimer <= 0.05):
+						PlayerCharacter.idleTimer = 0.05
 		
 	# check if the action is pressed
 	if (Input.is_action_just_pressed(action)):


### PR DESCRIPTION
Basically if you had a character (that used AnimatedSprite instead of AnimationPlayer) and you pressed a direction / note, the game would lag. I have fixed this, and also added actual support for AnimatedSprites because apparently it actually wasn't in the base repo.